### PR TITLE
Schedule Detail Page

### DIFF
--- a/src/containers/signedin/SchedulePage/ScheduleDetailsPage/index.js
+++ b/src/containers/signedin/SchedulePage/ScheduleDetailsPage/index.js
@@ -1,27 +1,94 @@
 import React, { Component } from "react";
-import { View, Text, ScrollView } from "react-native";
+import { View, Text, ScrollView, Image } from "react-native";
 import {
   Header,
-  TabbedMenu
+  TabbedMenu,
+  Card,
+  ListItem
 } from "../../../../components";
 import PageStyle from "./styles";
 class ScheduleDetailsPage extends Component {
+
+
+  
+  renderEventDetails(){
+    const { navigation }  = this.props;
+    const eventTitle = navigation.getParam("eventTitle");
+    const description = navigation.getParam("description");
+    const name = navigation.getParam("name");
+    const nameTitle = navigation.getParam("nameTitle");
+    const topic = navigation.getParam("topic");
+    if(eventTitle){
+      return(
+        <View>
+          <Text style={PageStyle.header}>
+            ABOUT
+          </Text>
+          <Card>
+            <View style={PageStyle.detailsContainer}>
+              <Text style={PageStyle.title}>{topic}</Text>
+              <Text style={PageStyle.text}>{description}</Text>
+            </View>
+            <View style={PageStyle.listContainer}>
+              <ListItem>
+                <View style={PageStyle.speakerContainer}>
+                  <View>
+                    <Text style={PageStyle.title}>{name}</Text>
+                    <Text style={PageStyle.text}>{nameTitle}</Text>
+                  </View>
+                  <View style={PageStyle.linkedInContainer}>
+                    <Image
+                        style={PageStyle.linkedInButton}
+                        source={require("../../../../assets/linkedin.png")}
+                      />
+                  </View>
+                </View>
+              </ListItem>
+            </View>
+            
+          </Card>
+        </View>
+      );
+    }
+
+  }
+
+
   render() {
     const { navigation }  = this.props;
-    const floorplan = navigation.getParam("location");
+    const location = navigation.getParam("location");
+    const floorplan = navigation.getParam("imageURL");
+    const label =navigation.getParam("label");
     return (
       <View style={PageStyle.container}>
         <Header
-          label="SCHEDULE DETAILS"
-          onPress={() => navigation.dispatch(DrawerActions.openDrawer())}
+          label={label.toUpperCase()}
+          status="details"
+          onPress={() => {
+            navigation.goBack();
+          }}
+          // onPress={() => navigation.dispatch(DrawerActions.openDrawer())}
         />
         <ScrollView>
-          <Text>
+          {this.renderEventDetails()}
+          <Text style={PageStyle.header}>
             LOCATION
           </Text>
-          <Text>
-            {floorplan}
-          </Text>
+          <Card>
+            <View style={PageStyle.locationContainerStyle}>
+              <View>
+                <Text style={PageStyle.title}>
+                  {location}
+                </Text>
+              </View>
+              <View>
+               <Image source={require("../../../../assets/checkin_button.png")} style={PageStyle.locationIconStyle}/>
+              </View>
+            </View>
+            {/* <Image source={floorplan}  style={PageStyle.mapImage/> */}
+            <Image source={require("../../../../assets/floor_map.png")} style={PageStyle.mapImage}/>
+          </Card>
+          
         </ScrollView>
         <TabbedMenu status="loggedin" navigation={navigation} />
       </View>

--- a/src/containers/signedin/SchedulePage/ScheduleDetailsPage/styles.js
+++ b/src/containers/signedin/SchedulePage/ScheduleDetailsPage/styles.js
@@ -1,12 +1,80 @@
 import { Dimensions } from "react-native";
+import { GRAY, DARK_GRAY, DARK_BLUE } from "../../../../styles/common";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
 const SCREEN_HEIGHT = Dimensions.get("window").height;
 
 export default (PageStyle = {
   container: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center"
+    flex: 1
+  },
+  mapImage: {
+    width: SCREEN_WIDTH * 0.95,
+    height: SCREEN_HEIGHT * 0.6,
+    resizeMode: "contain"
+  },
+  header: {
+    fontSize: 20,
+    padding: SCREEN_WIDTH * 0.025,
+    color: DARK_GRAY,
+    fontWeight: "500",
+    marginTop: SCREEN_HEIGHT * 0.02,
+    paddingBottom: SCREEN_HEIGHT * 0.0175
+  },
+  locationContainerStyle: {
+    width: "90%",
+    backgroundColor: "#ffffff",
+    marginRight: SCREEN_WIDTH * 0.05,
+    marginLeft: SCREEN_WIDTH * 0.05,
+    // marginLeft: SCREEN_WIDTH * 0.01,
+    paddingTop: SCREEN_HEIGHT * 0.03,
+    paddingBottom: SCREEN_HEIGHT * 0.03,
+    justifyContent: "space-between",
+    flexDirection: "row",
+    borderColor: GRAY,
+    borderBottomWidth: 1,
+  },
+  title: {
+    fontSize: 15,
+    color: DARK_GRAY,
+    fontWeight: "600"
+  },
+  text: {
+    color: GRAY
+  },
+  locationIconStyle: {
+    tintColor: DARK_BLUE,
+    // width: SCREEN_WIDTH * 0.5,
+    height: SCREEN_HEIGHT * 0.025,
+    resizeMode: "contain",
+  },
+  linkedInButton: {
+    width: SCREEN_WIDTH * 0.2,
+    height: SCREEN_HEIGHT * 0.04,
+    resizeMode: "contain",
+    // alignSelf: "center"
+  },
+  detailsContainer: {
+    width:"90%",
+    backgroundColor: "#ffffff",
+    marginRight: SCREEN_WIDTH * 0.05,
+    marginLeft: SCREEN_WIDTH * 0.05,
+    // marginLeft: SCREEN_WIDTH * 0.01,
+    paddingTop: SCREEN_HEIGHT * 0.03,
+    paddingBottom: SCREEN_HEIGHT * 0.03,
+    borderColor: GRAY,
+    borderBottomWidth: 1,
+  },
+  listContainer: {
+    width:"95%"
+  },
+  speakerContainer: {
+    width:"95%",
+    flexDirection: "row",
+    marginRight: SCREEN_WIDTH * 0.02,
+    marginLeft: SCREEN_WIDTH * 0.02,
+    paddingTop: SCREEN_HEIGHT * 0.03,
+    paddingBottom: SCREEN_HEIGHT * 0.03,
+    justifyContent:"space-between",
   }
 });

--- a/src/containers/signedin/SchedulePage/index.js
+++ b/src/containers/signedin/SchedulePage/index.js
@@ -19,7 +19,7 @@ class SchedulePage extends Component {
         title: "Registration and Breakfast Networking",
         floorplan: {
           location: "Grand Ballroom",
-          image: require("../../../assets/event.png")
+          image: require("../../../assets/floor_map.png")
         },
         events: []
       },
@@ -36,7 +36,7 @@ class SchedulePage extends Component {
         title: "Opening Remarks",
         floorplan: {
           location: "Grand Ballroom",
-          image: require("../../../assets/event.png")
+          image: require("../../../assets/floor_map.png")
         },
         events: []
       },
@@ -53,7 +53,7 @@ class SchedulePage extends Component {
         title: "First Speaker",
         floorplan: {
           location: "Grand Ballroom",
-          image: require("../../../assets/event.png")
+          image: require("../../../assets/floor_map.png")
         },
         events: []
       },
@@ -70,7 +70,7 @@ class SchedulePage extends Component {
         title: "Lunch",
         floorplan: {
           location: "Grand Ballroom",
-          image: require("../../../assets/event.png")
+          image: require("../../../assets/floor_map.png")
         },
         events: []
       }
@@ -91,39 +91,63 @@ class SchedulePage extends Component {
         title: "Breakout Session",
         floorplan: {
           location: "Grand Ballroom",
-          image: require("../../../assets/event.png")
+          image: require("../../../assets/floor_map.png")
         },
         events: [
           {
             id: 0,
             title: "Big Data and Analytics",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           },
           {
             id: 1,
             title: "AI and Machine Learning",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           },
           {
             id: 2,
             title: "Internet of Things (IoT)",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           },
           {
             id: 3,
             title: "Devops",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           }
         ]
@@ -141,39 +165,63 @@ class SchedulePage extends Component {
         title: "Last Speaker",
         floorplan: {
           location: "Grand Ballroom",
-          image: require("../../../assets/event.png")
+          image: require("../../../assets/floor_map.png")
         },
         events: [
           {
             id: 0,
             title: "Big Data and Analytics 4",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom 4",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           },
           {
             id: 1,
             title: "AI and Machine Learning",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           },
           {
             id: 2,
             title: "Internet of Things (IoT)",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           },
           {
             id: 3,
             title: "Devops",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           }
         ]
@@ -191,39 +239,64 @@ class SchedulePage extends Component {
         title: "Closing Remarks",
         floorplan: {
           location: "Grand Ballroom 2",
-          image: require("../../../assets/event.png")
+          image: require("../../../assets/floor_map.png")
         },
         events: [
           {
             id: 0,
             title: "Big Data and Analytics 2",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom 2",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
+            
           },
           {
             id: 1,
             title: "AI and Machine Learning",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           },
           {
             id: 2,
             title: "Internet of Things (IoT)",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           },
           {
             id: 3,
             title: "Devops",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           }
         ]
@@ -242,39 +315,63 @@ class SchedulePage extends Component {
         floorplan: 
         {
           location: "Grand Ballroom 3",
-          image: require("../../../assets/event.png")
+          image: require("../../../assets/floor_map.png")
         },
         events: [
           {
             id: 0,
             title: "Big Data and Analytics 3",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           },
           {
             id: 1,
             title: "AI and Machine Learning",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           },
           {
             id: 2,
             title: "Internet of Things (IoT)",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           },
           {
             id: 3,
             title: "Devops",
+            topic: "Building the next-gen Business",
+            description: "Round Table Discusion",
+            speaker: {
+              name: "Sang Young II",
+              title: "Alibaba CEO"
+            },
             floorplan: {
               location: "Grand Ballroom",
-              image: require("../../../assets/event.png")
+              image: require("../../../assets/floor_map.png")
             }
           }
         ]
@@ -296,14 +393,21 @@ class SchedulePage extends Component {
                     selectedIndex: id
                   },
                   () => {
+                    console.log(floorplan.image)
                     this.props.navigation.navigate("ScheduleDetailsPage",{
-                      location: floorplan.location
+                      location: floorplan.location,
+                      image: floorplan.image,
+                      label: "SCHEDULE DETAILS"
+                      // imageUrl: floorplan.image
                     })
+                    
                   }
                 );
               }}
             >
-              <View style={PageStyle.scheduleList}>
+              <View style={[
+                id == sessions.length-1 ? [PageStyle.scheduleList, { borderBottomWidth: 0 }]
+                : PageStyle.scheduleList]}>
                 <View>
                   <Text style={PageStyle.text}>
                     {time.startingHour}:{time.startingMinute} {time.meridian} - {time.endingHour}:{time.endingMinute} {time.meridian}
@@ -346,7 +450,14 @@ class SchedulePage extends Component {
                 () => {
                   this.props.navigation.navigate("ScheduleDetailsPage",
                     {
-                      location: events[id].floorplan.location
+                      label:  events[id].title,
+                      eventTitle: events[id].title,
+                      location: events[id].floorplan.location,
+                      image: events[id].floorplan.image,
+                      topic: events[id].topic,
+                      description: events[id].description,
+                      name: events[id].speaker.name,
+                      nameTitle: events[id].speaker.title
                     })
                 }
               );
@@ -363,6 +474,9 @@ class SchedulePage extends Component {
     });
     return event;
   };
+  renderFloorPlan(map) {
+    return <Image source={map.image} style={PageStyle.mapImage} />;
+  }
 
   render() {
     const { navigation } = this.props;


### PR DESCRIPTION
#Description

Edited data of Schedule Page, added topic, description and speaker, and changed the image of floorplan.

Created Schedule Detail Page.  All data in Schedule Detail Page is passed in the navigation from the Schedule Page. 

Added styling condition in schedule list so that the borderBottom will not be visible if it is the last item

#Screenshot of SchedulePage in IOS
WIthout Accordion:
<img width="401" alt="screen shot 2018-12-11 at 1 41 24 pm" src="https://user-images.githubusercontent.com/40556044/49780675-8aa0c780-fd4a-11e8-9ad4-886cc7ccf579.png">


With Accordion:
<img width="390" alt="screen shot 2018-12-11 at 1 41 10 pm" src="https://user-images.githubusercontent.com/40556044/49780689-97bdb680-fd4a-11e8-87da-4e5f908352b3.png">

